### PR TITLE
feat: 持久化保存目录设置

### DIFF
--- a/musicdownload.py
+++ b/musicdownload.py
@@ -39,6 +39,7 @@ from PySide6.QtCore import (
     QThreadPool,
     QRunnable,
     QObject,
+    QSettings,
 )
 from PySide6.QtGui import QPixmap, QFont, QColor, QPainter, QAction
 
@@ -481,7 +482,12 @@ class MusicDownloader(QMainWindow):
         self.thread_pool.setMaxThreadCount(10)
 
         self.current_dir = os.getcwd()
-        self.save_dir = os.path.join(self.current_dir, "已下载音乐")
+        self.settings = QSettings("musicDownload", "MusicDownloader")
+        saved = self.settings.value("save_dir", "")
+        if saved and os.path.isdir(saved):
+            self.save_dir = saved
+        else:
+            self.save_dir = os.path.join(self.current_dir, "已下载音乐")
         os.makedirs(self.save_dir, exist_ok=True)
 
         self.auto_download_after_search = False
@@ -762,6 +768,7 @@ class MusicDownloader(QMainWindow):
         if dir_path:
             self.save_dir = dir_path
             self.save_dir_edit.setText(dir_path)
+            self.settings.setValue("save_dir", dir_path)
 
     def init_music_client(self):
         if not MUSICDL_AVAILABLE:

--- a/musicdownload_debug.py
+++ b/musicdownload_debug.py
@@ -39,6 +39,7 @@ from PySide6.QtCore import (
     QThreadPool,
     QRunnable,
     QObject,
+    QSettings,
 )
 from PySide6.QtGui import QPixmap, QFont, QColor, QPainter, QAction
 
@@ -481,7 +482,12 @@ class MusicDownloader(QMainWindow):
         self.thread_pool.setMaxThreadCount(10)
 
         self.current_dir = os.getcwd()
-        self.save_dir = os.path.join(self.current_dir, "已下载音乐")
+        self.settings = QSettings("musicDownload", "MusicDownloader")
+        saved = self.settings.value("save_dir", "")
+        if saved and os.path.isdir(saved):
+            self.save_dir = saved
+        else:
+            self.save_dir = os.path.join(self.current_dir, "已下载音乐")
         os.makedirs(self.save_dir, exist_ok=True)
 
         self.auto_download_after_search = False
@@ -762,6 +768,7 @@ class MusicDownloader(QMainWindow):
         if dir_path:
             self.save_dir = dir_path
             self.save_dir_edit.setText(dir_path)
+            self.settings.setValue("save_dir", dir_path)
 
     def init_music_client(self):
         if not MUSICDL_AVAILABLE:

--- a/musicdownload_test.py
+++ b/musicdownload_test.py
@@ -39,6 +39,7 @@ from PySide6.QtCore import (
     QThreadPool,
     QRunnable,
     QObject,
+    QSettings,
 )
 from PySide6.QtGui import QPixmap, QFont, QColor, QPainter, QAction
 
@@ -481,7 +482,12 @@ class MusicDownloader(QMainWindow):
         self.thread_pool.setMaxThreadCount(10)
 
         self.current_dir = os.getcwd()
-        self.save_dir = os.path.join(self.current_dir, "已下载音乐")
+        self.settings = QSettings("musicDownload", "MusicDownloader")
+        saved = self.settings.value("save_dir", "")
+        if saved and os.path.isdir(saved):
+            self.save_dir = saved
+        else:
+            self.save_dir = os.path.join(self.current_dir, "已下载音乐")
         os.makedirs(self.save_dir, exist_ok=True)
 
         self.auto_download_after_search = False
@@ -762,6 +768,7 @@ class MusicDownloader(QMainWindow):
         if dir_path:
             self.save_dir = dir_path
             self.save_dir_edit.setText(dir_path)
+            self.settings.setValue("save_dir", dir_path)
 
     def init_music_client(self):
         if not MUSICDL_AVAILABLE:


### PR DESCRIPTION
## 改动说明

使用 `QSettings` 在用户通过浏览选择保存目录后自动持久化，下次启动时自动恢复上次选择的目录。

### 具体变更
- **初始化时**：从 `QSettings` 读取保存目录，无效则回退到默认值 `{cwd}/已下载音乐`
- **浏览选择后**：自动调用 `settings.setValue(save_dir, dir_path)` 持久化
- **三个文件同步修改**：`musicdownload.py`、`musicdownload_debug.py`、`musicdownload_test.py`

### 跨平台兼容
QSettings 在各平台存储位置不同，用法一致：
- Linux: `~/.config/musicDownload/MusicDownloader.conf`
- Windows: 注册表 `HKCU\Software\musicDownload\MusicDownloader`
- macOS: `~/Library/Preferences/com.musicDownload.MusicDownloader.plist`